### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -19,6 +21,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: lint
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v4
     - name: build
@@ -44,6 +48,8 @@ jobs:
   image:
     runs-on: ubuntu-latest
     needs: release
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: build image


### PR DESCRIPTION
Potential fix for [https://github.com/ppussar/mongodb_exporter/security/code-scanning/3](https://github.com/ppussar/mongodb_exporter/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the `image` job. This block should specify the least privileges required for the job to function correctly. Since the job does not interact with repository contents, we can set `contents: read` as the minimal permission. This ensures the job does not inadvertently gain write access to the repository.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
